### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Walkoff apps can be found at: https://github.com/iadgov/WALKOFF-Apps
     * Can granularly configure which events to log on a per-case basis
 
 4. Drag and Drop Workflow Editor
-    * Makes creation and editing of workflows as easy as dragging and dropping capablities. 
+    * Makes creation and editing of workflows as easy as dragging and dropping capabilities.
     
 5. Flexible Workflow Execution
     * Manual Execution - Execute a workflow by pressing a button

--- a/apps/ARDrone/libardrone/arnetwork.py
+++ b/apps/ARDrone/libardrone/arnetwork.py
@@ -92,7 +92,7 @@ class IPCThread(threading.Thread):
     """Inter Process Communication Thread.
 
     This thread collects the data from the ARDroneNetworkProcess and forwards
-    it to the ARDreone.
+    it to the ARDrone.
     """
 
     def __init__(self, drone):

--- a/apps/ARDrone/libardrone/arvideo.py
+++ b/apps/ARDrone/libardrone/arvideo.py
@@ -209,7 +209,7 @@ def _first_half(data):
 
 
 def _second_half(data):
-    """Helper function to precompute the nonzeror values in a 15 bit datum.
+    """Helper function to precompute the non-zero values in a 15 bit datum.
     """
     # data has to be 15 bits wide
     streamlen = 0
@@ -250,7 +250,7 @@ class BitReader(object):
         self.read_bits = 0
 
     def read(self, nbits, consume=True):
-        """Read nbits and return the integervalue of the read bits.
+        """Read nbits and return the integer value of the read bits.
 
         If consume is False, it behaves like a 'peek' method (ie it reads the
         bits but does not consume them.

--- a/apps/ARDrone/libardrone/libardrone.py
+++ b/apps/ARDrone/libardrone/libardrone.py
@@ -46,7 +46,7 @@ ARDRONE_COMMAND_PORT = 5556
 class ARDrone(object):
     """ARDrone Class.
 
-    Instanciate this class to control your drone and receive decoded video and
+    Instantiate this class to control your drone and receive decoded video and
     navdata.
     """
 
@@ -148,7 +148,7 @@ class ARDrone(object):
     def commwdg(self):
         """Communication watchdog signal.
 
-        This needs to be send regulary to keep the communication w/ the drone
+        This needs to be send regularly to keep the communication w/ the drone
         alive.
         """
         self.at(at_comwdg)
@@ -285,7 +285,7 @@ def at_led(seq, anim, f, d):
     Parameters:
     seq -- sequence number
     anim -- Integer: animation to play
-    f -- ?: frequence in HZ of the animation
+    f -- ?: frequency in HZ of the animation
     d -- Integer: total duration in seconds of the animation
     """
     pass
@@ -295,7 +295,7 @@ def at_anim(seq, anim, d):
     Makes the drone execute a predefined movement (animation).
 
     Parameters:
-    seq -- sequcence number
+    seq -- sequence number
     anim -- Integer: animation to play
     d -- Integer: total duration in sections of the animation
     """

--- a/core/case/callbacks.py
+++ b/core/case/callbacks.py
@@ -63,7 +63,7 @@ def __construct_logging_signal(event_type, message_name, entry_message):
         module variable for the signal to work.
         
     Args:
-        event_type (str): Type of event whcih is logged 'Workflow, Step, etc.'
+        event_type (str): Type of event which is logged 'Workflow, Step, etc.'
         message_name (str): Name of message
         entry_message (str): More detailed message to log
         data (str): Extra information

--- a/core/case/database.py
+++ b/core/case/database.py
@@ -110,7 +110,7 @@ class Event(_Base):
 
 class CaseDatabase(object):
     """
-    Wrapper for the SQLAlchhemy Case database object
+    Wrapper for the SQLAlchemy Case database object
     """
     def __init__(self):
         self.create()

--- a/core/controller.py
+++ b/core/controller.py
@@ -115,7 +115,7 @@ class Controller(object):
 
     # TODO: Turns out this doesn't work at all
     def __workflow_completed_callback(self, workflow, **kwargs):
-        print('COMPLETEDE')
+        print('COMPLETED')
         if workflow.uuid in self.workflow_status:
             self.workflow_status[workflow.uuid] = WORKFLOW_COMPLETED
 

--- a/core/workflow.py
+++ b/core/workflow.py
@@ -60,7 +60,7 @@ class Workflow(ExecutionElement):
         """Retrieve a workflow from the name of the workflow.
         
         Args:
-            workflow_name: The name of the Workflow objet to be retrieved.
+            workflow_name: The name of the Workflow object to be retrieved.
             
         Returns:
             The Workflow object from the provided workflow name.

--- a/tests/test_app_utilities.py
+++ b/tests/test_app_utilities.py
@@ -22,10 +22,10 @@ class TestAppUtilities(unittest.TestCase):
         with flaskserver.running_context.flask_app.app_context():
             create_user()
 
-    def test_get_all_devices_for_nonexistant_app_empty_db(self):
-        self.assertListEqual(App.get_all_devices_for_app('non-existant-app'), [])
+    def test_get_all_devices_for_nonexistent_app_empty_db(self):
+        self.assertListEqual(App.get_all_devices_for_app('non-existent-app'), [])
 
-    def test_get_all_devices_for_nonexistant_app_full_db(self):
+    def test_get_all_devices_for_nonexistent_app_full_db(self):
         for app_name in ['App1', 'App2', 'App3']:
             flaskserver.running_context.db.session.add(flaskserver.running_context.App(app=app_name, devices=[]))
         flaskserver.running_context.db.session.commit()
@@ -42,8 +42,8 @@ class TestAppUtilities(unittest.TestCase):
         flaskserver.running_context.db.session.commit()
         self.assertListEqual(App.get_all_devices_for_app('App1'), [])
 
-    def test_get_device_for_nonexistant_app_and_device_empty_db(self):
-        self.assertIsNone(App.get_device('non-existant-app', 'nonexistant-device'))
+    def test_get_device_for_nonexistent_app_and_device_empty_db(self):
+        self.assertIsNone(App.get_device('non-existent-app', 'nonexistent-device'))
 
     @staticmethod
     def __setup_database():
@@ -52,26 +52,26 @@ class TestAppUtilities(unittest.TestCase):
         flaskserver.running_context.db.session.add(flaskserver.running_context.App(app='App3', devices=['a', 'c', 'd']))
         flaskserver.running_context.db.session.commit()
 
-    def test_get_device_for_nonexistant_app_device(self):
+    def test_get_device_for_nonexistent_app_device(self):
         self.__setup_database()
-        self.assertIsNone(App.get_device('non-existant-app', 'nonexistant-device'))
+        self.assertIsNone(App.get_device('non-existent-app', 'nonexistent-device'))
 
-    def test_get_device_for_nonexistant_app_existing_device(self):
+    def test_get_device_for_nonexistent_app_existing_device(self):
         self.__setup_database()
         for device_name in ['a', 'b', 'c', 'd']:
-            self.assertIsNone(App.get_device('non-existiant-app', device_name))
+            self.assertIsNone(App.get_device('non-existent-app', device_name))
 
-    def test_get_device_for_existant_app_nonexistant_device(self):
+    def test_get_device_for_existent_app_nonexistent_device(self):
         self.__setup_database()
         for app_name in ['App1', 'App2', 'App3']:
-            self.assertIsNone(App.get_device(app_name, 'non-existant-device'))
+            self.assertIsNone(App.get_device(app_name, 'non-existent-device'))
 
-    def test_get_device_for_existant_app_no_devices(self):
+    def test_get_device_for_existent_app_no_devices(self):
         self.__setup_database()
         for device_name in ['a', 'b', 'c', 'd']:
             self.assertIsNone(App.get_device('App1', device_name))
 
-    def test_get_device_for_existant_app_with_devices(self):
+    def test_get_device_for_existent_app_with_devices(self):
         self.__setup_database()
         app_devices = {'App2': ['a', 'b'],
                        'App3': ['a', 'c', 'd']}

--- a/tests/test_case_server.py
+++ b/tests/test_case_server.py
@@ -106,9 +106,9 @@ class TestCaseServer(ServerTestCase):
                                for event in response['case']['events']]
             expected_events = [{key: event[key] for key in ['type', 'message', 'ancestry']}
                                for event in expected_events]
-            self.assertEqual(len(received_events), len(expected_events), 'Unexpected number of events receieved')
+            self.assertEqual(len(received_events), len(expected_events), 'Unexpected number of events received')
             for event in expected_events:
-                self.assertTrue(event in received_events, 'Expected event is not in receieved events')
+                self.assertTrue(event in received_events, 'Expected event is not in received events')
 
     def test_add_case_no_existing_cases(self):
         response = self.app.put('/cases/case1', headers=self.headers)

--- a/tests/test_case_subscriptions.py
+++ b/tests/test_case_subscriptions.py
@@ -351,7 +351,7 @@ class TestSubscriptionFunctions(unittest.TestCase):
 
     def test_edit_global_subscription_invalid_case(self):
         global_subs = GlobalSubscriptions()
-        self.assertFalse(edit_global_subscription('nonesense_case_name', global_subs))
+        self.assertFalse(edit_global_subscription('nonsense_case_name', global_subs))
 
     def test_edit_subscriptions(self):
         case1, acceptance1 = construct_case1()
@@ -384,7 +384,7 @@ class TestSubscriptionFunctions(unittest.TestCase):
         cases = {'case2': case_sub}
         set_subscriptions(cases)
         original_subscriptions = copy.deepcopy(get_subscriptions())
-        self.assertFalse(edit_subscription('nonesense_case', ['a', 'b', 'c'], ['d', 'e']))
+        self.assertFalse(edit_subscription('nonsense_case', ['a', 'b', 'c'], ['d', 'e']))
         # Apparently assertDictEquals says this is false. Infuriating.
         self.assertEqual(str(original_subscriptions), str(get_subscriptions()))
 
@@ -419,7 +419,7 @@ class TestSubscriptionFunctions(unittest.TestCase):
         cases = {'case2': case_sub}
         set_subscriptions(cases)
         original_subscriptions = copy.deepcopy(get_subscriptions())
-        self.assertFalse(add_subscription('nonesense_case', ['a', 'b', 'c'], ['d', 'e']))
+        self.assertFalse(add_subscription('nonsense_case', ['a', 'b', 'c'], ['d', 'e']))
         # Apparently assertDictEquals says this is false. Infuriating.
         self.assertEqual(str(original_subscriptions), str(get_subscriptions()))
 
@@ -555,6 +555,6 @@ class TestSubscriptionFunctions(unittest.TestCase):
         cases = {'case2': case_sub}
         set_subscriptions(cases)
         original_subscriptions = copy.deepcopy(get_subscriptions())
-        self.assertFalse(remove_subscription_node('nonesense_case', ['a', 'b', 'c']))
+        self.assertFalse(remove_subscription_node('nonsense_case', ['a', 'b', 'c']))
         # Apparently assertDictEquals says this is false. Infuriating.
         self.assertEqual(str(original_subscriptions), str(get_subscriptions()))

--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -70,26 +70,26 @@ class MetricsServerTest(ServerTestCase):
 
 
     def test_convert_workflow_time_average(self):
-        test1 = {'worfklow1': {'count': 0,
+        test1 = {'workflow1': {'count': 0,
                                'avg_time': timedelta(100, 0, 1)},
-                 'worfklow2': {'count': 2,
+                 'workflow2': {'count': 2,
                                'avg_time': timedelta(0, 0, 1000)},
-                 'worfklow3': {'count': 0,
+                 'workflow3': {'count': 0,
                                'avg_time': timedelta(0, 100, 1)},
-                 'worfklow4': {'count': 100,
+                 'workflow4': {'count': 100,
                                'avg_time': timedelta(1, 100, 500)}}
         expected_json = {'workflows': [{'count': 100,
                                         'avg_time': '1 day, 0:01:40.000500',
-                                        'name': 'worfklow4'},
+                                        'name': 'workflow4'},
                                        {'count': 2,
                                         'avg_time': '0:00:00.001000',
-                                        'name': 'worfklow2'},
+                                        'name': 'workflow2'},
                                        {'count': 0,
                                         'avg_time': '0:01:40.000001',
-                                        'name': 'worfklow3'},
+                                        'name': 'workflow3'},
                                        {'count': 0,
                                         'avg_time': '100 days, 0:00:00.000001',
-                                        'name': 'worfklow1'}]}
+                                        'name': 'workflow1'}]}
         metrics.workflow_metrics = test1
         converted = _convert_workflow_time_averages()
         orderless_list_compare(self, converted.keys(), ['workflows'])


### PR DESCRIPTION
I noticed a typo in the README and then found a few more throughout the repo. This PR fixes them.

---
There was one I wasn't sure about but I'd be more than happy to add another commit to this PR if changing it is necessary.

`"subtractor"` is being used in two functions (and then referenced in two yaml files) but it doesn't seem to be the correct term...

```python
# core/filters/math.py
@datafilter
def subtract(value, subtractor):
    return value - subtractor

# Utilities/main.py
@action
def subtract(self, value, subtractor):
    return value - subtractor
```

> [Formally, the number being subtracted is known as the ***subtrahend***, while the number it is subtracted from is the ***minuend***. The result is the ***difference***.](https://en.wikipedia.org/wiki/Subtraction#Notation_and_terminology)

> [In subtraction, a ***subtrahend*** is subtracted from a ***minuend*** to find a ***difference***.](https://www.factmonster.com/math/tables-and-formulas/terms-used-equations)
